### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: File a bug report to help us improve this project
+title: "Bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Give a clear description of what the bug is and the current behavior.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Provide a step-by-step instructions to reproduce the bug. Include links to files or GitHub projects, or copy and paste the snippets that you use.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: Explain the behavior you expected to see and why.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Screenshots or screen recordings
+      description: Please provide screenshots or screen recordings to show the problem.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      multiple: true
+      label: Browsers
+      description: What browsers are you seeing the problem on?
+      options:
+        - "Chrome"
+        - "Firefox"
+        - "Safari"
+        - "Edge"
+        - "Opera"
+        - "Other (add additional context)"
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/petermsouzajr/cy-shadow-report/blob/main/CONTRIBUTING.md#code-of-conduct)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,7 +52,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/petermsouzajr/cy-shadow-report/blob/main/CONTRIBUTING.md#code-of-conduct)
+      description: By submitting this issue, you agree to follow our [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/petermsouzajr/cy-shadow-report/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug report
+name: 🐞 Bug report
 description: File a bug report to help us improve this project
 title: "Bug: "
 labels: [bug]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,14 +10,14 @@ body:
   - type: textarea
     attributes:
       label: Describe the suggestion
-      description: Give a clear description and examples of what kind of enhancement you would like to see.
+      description: Give a clear description and examples of what kind of feature you would like to see.
     validations:
       required: true
   - type: dropdown
     attributes:
       multiple: false
-      label: Type of enhancement
-      description: Select the type of enhancement request.
+      label: Type of feature
+      description: Select the type of feature request.
       options:
         - "✨ Feature"
         - "🐞 Fix"
@@ -27,20 +27,20 @@ body:
   - type: textarea
     attributes:
       label: Current behavior
-      description: Describe the current behavior and how your enhancement would change/improve it.
+      description: Describe the current behavior and how your feature would change/improve it.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Suggested solution
-      description: Explain your solution and why this enhancement would be useful to most cy-shadow-report users.
+      description: Explain your solution and why this feature would be useful to most cy-shadow-report users.
     validations:
       required: true
   - type: input
     id: context
     attributes:
       label: Additional context
-      description: List some other projects where this enhancement exists.
+      description: List some other projects where this feature exists.
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: ✨ Feature request
+description: Suggest an enhancement idea for this project
+title: "Feature: "
+labels: [feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    attributes:
+      label: Describe the suggestion
+      description: Give a clear description and examples of what kind of enhancement you would like to see.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      multiple: false
+      label: Type of enhancement
+      description: Select the type of enhancement request.
+      options:
+        - "✨ Feature"
+        - "🐞 Fix"
+        - "📝 Documentation"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current behavior
+      description: Describe the current behavior and how your enhancement would change/improve it.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Suggested solution
+      description: Explain your solution and why this enhancement would be useful to most cy-shadow-report users.
+    validations:
+      required: true
+  - type: input
+    id: context
+    attributes:
+      label: Additional context
+      description: List some other projects where this enhancement exists.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/petermsouzajr/cy-shadow-report/blob/main/CONTRIBUTING.md#code-of-conduct)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,6 +22,7 @@ body:
         - "✨ Feature"
         - "🐞 Fix"
         - "📝 Documentation"
+        - "💻 Refactor"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -48,7 +48,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/petermsouzajr/cy-shadow-report/blob/main/CONTRIBUTING.md#code-of-conduct)
+      description: By submitting this issue, you agree to follow our [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/petermsouzajr/cy-shadow-report/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,28 +14,6 @@ If your question or issue is not addressed yet, feel free to open a new issue.
 
 ## How Can I Contribute?
 
-### Reporting Bugs
-
-This section guides you through submitting a bug report for cy-shadow-report. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
-
-- **Use a clear and descriptive title** for the issue to identify the problem.
-- **Provide a step-by-step description of the bug** in as much detail as possible.
-- **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples.
-- **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
-- **Explain which behavior you expected to see instead and why.**
-- **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.
-
-### Suggesting Enhancements
-
-This section guides you through submitting an enhancement suggestion for cy-shadow-report, including completely new features and minor improvements to existing functionality.
-
-- **Use a clear and descriptive title** for the issue to identify the suggestion.
-- **Provide a step-by-step description of the suggested enhancement** in as much detail as possible.
-- **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples.
-- **Describe the current behavior and how your feature would change/improve it.**
-- **Explain why this enhancement would be useful** to most cy-shadow-report users.
-- **List some other projects where this enhancement exists.**
-
 ### Your First Code Contribution
 
 Unsure where to begin contributing to cy-shadow-report? You can start by looking through `beginner` and `help-wanted` issues:


### PR DESCRIPTION
## Description

This PR holds changes as below:

- Add issue templates for bug reporting and feature request.
- Remove the "Reporting Bugs" and "Suggesting Enhancements" sections from the `CONTRIBUTING.md`.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Code Refactor

## Related Tickets/Issues

Closes #38

## How Has This Been Tested?

No tested needed.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, run: `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes, run: `npm test`
